### PR TITLE
Household names have length limit in 4.6

### DIFF
--- a/Civi/Anonymize/SQL/Templates/update_household_name.sql.twig
+++ b/Civi/Anonymize/SQL/Templates/update_household_name.sql.twig
@@ -7,18 +7,24 @@ INSERT INTO household_name
   SELECT
     household.id,
     IF( COUNT(*) > 1,
-      GROUP_CONCAT(
-        DISTINCT
+      LEFT(
+        GROUP_CONCAT(
+          DISTINCT
+          CONCAT(
+            related_individual.first_name, " ",
+            related_individual.last_name
+          )
+          ORDER BY related_individual.last_name
+          SEPARATOR ' & '
+        ),
+        128
+      ),
+      LEFT(
         CONCAT(
           related_individual.first_name, " ",
-          related_individual.last_name
-        )
-        ORDER BY related_individual.last_name
-        SEPARATOR ' and '
-      ),
-      CONCAT(
-        related_individual.first_name, " ",
-        related_individual.last_name, " Household"
+          related_individual.last_name, " Household"
+        ),
+      128
       )
     )
   FROM civicrm_contact household


### PR DESCRIPTION
Issue #12 - household names generated by SQL anonymization could be overlong for table definitions in 4.6.8.

@com2 Do you think there's a way we could do this and have MySQL automatically drop the extra characters, rather than locking in the CONCAT?